### PR TITLE
Fixed a bug in genome circles view: NON_CDS features with + strand ar…

### DIFF
--- a/public/js/p3/widget/CircularViewerContainer.js
+++ b/public/js/p3/widget/CircularViewerContainer.js
@@ -83,19 +83,19 @@ define([
 				},
 				handleAs: "json"
 			}).then(lang.hitch(this, function(refseqs){
-				//console.log("******track title:", title, " refseqs:", refseqs);
+				//console.log("******track title:", title, " refseqs:", refseqs, " strand", strand);
 				
 				if (refseqs.length == 0) {
 					track.set('loading', false);
 					return refseqs;
 				} 
-				
+								
 				refseqs = refseqs.filter(function(r){
 					if(strand === null){
 						return true;
 					}
 					if(strand){
-						return r.strand && r.strand == "+"
+						return r.strand && r.strand == "+";
 					}else{
 						return r.strand != "+";
 					}
@@ -108,9 +108,7 @@ define([
 				})
 
 				//console.log("******before set data track title:", title, " refseqs:", refseqs);
-
 				track.set("data", refseqs);
-				//console.log("******after track title:", title, " refseqs:", refseqs);
 
 				return refseqs;
 			}));
@@ -166,7 +164,7 @@ define([
 						return "#21DFD7";
 				}
 			};
-			this.addFeatureTrack("Non-CDS Features", this.state.genome_ids[0], "and(eq(annotation,PATRIC),ne(feature_type,CDS))", false, fillFn, null, {
+			this.addFeatureTrack("Non-CDS Features", this.state.genome_ids[0], "and(eq(annotation,PATRIC),ne(feature_type,CDS))", null, fillFn, null, {
 				fill: null,
 				stroke: null
 			});


### PR DESCRIPTION
…e not shown. Also, if all NON_CDS features are + strand, the loading message keeps spinning.