### PR TITLE
merge djm

### DIFF
--- a/public/js/p3/widget/ProteinFamiliesGrid.js
+++ b/public/js/p3/widget/ProteinFamiliesGrid.js
@@ -1,11 +1,11 @@
 define([
 	"dojo/_base/declare", "dojo/_base/lang", "dojo/_base/Deferred",
 	"dojo/on", "dojo/dom-class", "dojo/dom-construct", "dojo/aspect", "dojo/request", "dojo/topic",
-	"dijit/layout/BorderContainer", "dijit/layout/ContentPane",
+	"dijit/layout/BorderContainer", "dijit/layout/ContentPane","./GridSelector",
 	"./PageGrid", "./formatter", "../store/ProteinFamiliesMemoryStore"
 ], function(declare, lang, Deferred,
 			on, domClass, domConstruct, aspect, request, Topic,
-			BorderContainer, ContentPane,
+			BorderContainer, ContentPane,selector,
 			Grid, formatter, Store){
 	return declare([Grid], {
 		region: "center",
@@ -18,7 +18,7 @@ define([
 		primaryKey: "feature_id",
 		deselectOnRefresh: true,
 		columns: {
-			// "Selection Checkboxes": selector({}),
+			"Selection Checkboxes": selector({}),
 			family_id: {label: 'ID', field: 'family_id'},
 			feature_count: {label: 'Proteins', field: 'feature_count'},
 			genome_count: {label: 'Genomes', field: 'genome_count'},

--- a/public/js/p3/widget/WorkspaceBrowser.js
+++ b/public/js/p3/widget/WorkspaceBrowser.js
@@ -18,7 +18,7 @@ define([
 		disabled: false,
 		path: "/",
 		gutters: false,
-		navigableTypes: ["parentfolder", "folder", "genome_group", "feature_group", "job_result", "experiment_group", "experiment", "unspecified", "contigs", "reads", "model"],
+		navigableTypes: ["parentfolder", "folder", "job_result", "experiment_group", "experiment", "unspecified", "contigs", "reads", "model"],
 		design: "sidebar",
 		splitter: false,
 		startup: function(){


### PR DESCRIPTION
enables checkboxes on ProteinFamilies and GeneExpression Grids.  Select All functionality still needs to be implemented (or disabled) for those grids.

Also disabled drill down into groups within the workspace.