### PR TITLE
Build script fix for large systems

### DIFF
--- a/buildClient.sh
+++ b/buildClient.sh
@@ -1,5 +1,13 @@
 #!/bin/sh     
 
+maxParam=""
+if [ -f /proc/cpuinfo ] ; then
+    cpus=`grep -c "^processor[[:space:]]*:" /proc/cpuinfo`
+    if [ $cpus -gt 10 ] ; then
+	maxParam="maxOptimizationProcesses=10"
+    fi
+fi
+
 cd public/js/
-./util/buildscripts/build.sh --profile ./release.profile.js --release 
+./util/buildscripts/build.sh --profile ./release.profile.js --release  $maxParam
 cd ../../


### PR DESCRIPTION
Detect large CPU count systems and don't allow the build to use all of them.

Avoids out of memory crashes.