### PR TITLE
patch to fix new folder button

### DIFF
--- a/public/js/p3/widget/WorkspaceObjectSelector.js
+++ b/public/js/p3/widget/WorkspaceObjectSelector.js
@@ -445,10 +445,8 @@ define([
 					owner: {
 						label: "Owner",
 						field: "owner_id",
-						className: "wsItemCreationTime",
-						formatter: function(blah) {
-							return blah.split('@')[0];
-						},
+						className: "wsItemOwnerId",
+						formatter: formatter.baseUsername,
 						hidden: false
 					},
 					creation_time: {


### PR DESCRIPTION
This was an issue in the publicWorkspace branch since adding the owner column.   The new folder row in the grid doesn't initially have an owner_id, so error was being thrown.