### PR TITLE
show hidden files/folders in WSOSelector

### DIFF
--- a/public/js/p3/widget/WorkspaceExplorerView.js
+++ b/public/js/p3/widget/WorkspaceExplorerView.js
@@ -25,6 +25,14 @@ define([
 		queryOptions: {
 			sort: [{attribute: "name", descending: false}]
 		},
+
+		showHiddenFiles: window.App && window.App.showHiddenFiles,
+
+		_setShowHiddenFiles: function(val){
+			this.showHiddenFiles = val;
+			this.refreshWorkspace();
+		},
+
 		listWorkspaceContents: function(ws){
 			// console.log("[WorkspaceExplorerView] listWorkspaceContents()")
 			var _self = this;
@@ -47,7 +55,7 @@ define([
 			}
 
 			var filterPublic =  ws == '/' ? true : false;
-			var prom1 = WorkspaceManager.getFolderContents(ws, window.App && window.App.showHiddenFiles, null, filterPublic);
+			var prom1 = WorkspaceManager.getFolderContents(ws, this.showHiddenFiles, null, filterPublic);
 
 			// if listing user's top level, included 'shared with me' as well
 			var userID = window.App.user.id;

--- a/public/js/p3/widget/WorkspaceObjectSelector.js
+++ b/public/js/p3/widget/WorkspaceObjectSelector.js
@@ -25,6 +25,7 @@ define([
 		disabled: false,
 		required: false,
 		showUnspecified: false,
+		showHidden: false,
 		missingMessage: "A valid workspace item is required.",
 		promptMessage: "Please choose or upload a workspace item",
 		placeHolder: "",
@@ -56,6 +57,17 @@ define([
 				this.grid.set('types', this.type);
 			}
 		},
+
+		_setShowHiddenAttr: function(val){
+			this.showHidden = val;
+
+			console.log("set showHidden: ", val);
+
+			if(this.grid){
+				this.grid.set('showHiddenFiles', val);
+			}
+		},
+
 
 		_setDisabledAttr: function(val){
 			this.disabled = val;
@@ -371,6 +383,21 @@ define([
 			});
 			domConstr.place(this.showUnspecifiedWidget.domNode, span, "first");
 			domConstr.create("span", {innerHTML: "Show files with an unspecified type"}, span);
+
+			domConstr.create("br", {}, buttonsPane.containerNode);
+
+			var span2 = domConstr.create("span", {style: {"float": 'left'}});
+			domConstr.place(span2, buttonsPane.containerNode, "last");
+			this.showHiddenWidget = new CheckBox({value: this.showHidden, checked: this.showHidden});
+			this.showHiddenWidget.on("change", function(val){
+				_self.set("showHidden", val);
+			});
+			domConstr.place(this.showHiddenWidget.domNode, span2, "first");
+			domConstr.create("span", {innerHTML: "Show hidden files and folders"}, span2);
+
+
+
+
 			var cancelButton = new Button({label: "Cancel"});
 			cancelButton.on('click', function(){
 				_self.dialog.hide();
@@ -385,8 +412,8 @@ define([
 				_self.onSelection(_self.selection.path);
 				_self.dialog.hide();
 			});
+			domConstr.place(cancelButton.domNode, buttonsPane.containerNode, "last");
 			domConstr.place(okButton.domNode, buttonsPane.containerNode, "last");
-			domConstr.place(cancelButton.domNode, buttonsPane.containerNode, "first");
 
 
 			on(selectionPane.domNode, "i:click", function(evt){
@@ -574,6 +601,7 @@ define([
 				deselectOnRefresh: true,
 				onlyWritable: self.onlyWritable,
 				allowDragAndDrop: false,
+				showHiddenFiles: this.showHidden,
 				types: this.type ? (["folder"].concat(this.type)) : false,
 				columns: {
 					type: {


### PR DESCRIPTION
This patch adds a button to WorkspaceObject selector to allow  users to show hidden files and folders so that they can browse into .job result objects.