### PR TITLE
Rockhopper to Jbrowse

### DIFF
--- a/public/js/p3/widget/GenomeBrowser.js
+++ b/public/js/p3/widget/GenomeBrowser.js
@@ -324,7 +324,8 @@ define([
 				.replace(/^([a-z]*)0+/, '$1')
 				.replace(/^(\d+)$/, 'chr$1')
 				.replace(/^accn\|/, '')
-                .replace(/^sid\|\d+\|accn\|/,'');
+                .replace(/^sid\|\d+\|accn\|/,'')
+                .replace(/^[[:ascii:]]+\|accn\|/,'');
 
 			return refname;
 		},

--- a/public/js/p3/widget/GenomeBrowser.js
+++ b/public/js/p3/widget/GenomeBrowser.js
@@ -321,11 +321,13 @@ define([
 				.replace(/^chro?m?(osome)?/, 'chr')
 				.replace(/^co?n?ti?g/, 'ctg')
 				.replace(/^scaff?o?l?d?/, 'scaffold')
-				.replace(/^([a-z]*)0+/, '$1')
 				.replace(/^(\d+)$/, 'chr$1')
 				.replace(/^accn\|/, '')
-                .replace(/^sid\|\d+\|accn\|/,'')
-                .replace(/^[[:ascii:]]+\|accn\|/,'');
+                .replace(/^sid\|\d+\|accn\|/,'') // handle legacy PATRIC format
+                .replace(/^.+\|accn\|/,'') //handle crazy rockhopper id requirements
+                .replace(/\|$/g,''); //handle crazy rockhopper id requirements
+                //not sure what this was for but it was causing problems when loweringCase with ID like "JEZL01000001" turning to jezl1000001
+                //              .replace(/^([a-z]*)0+/, '$1')
 
 			return refname;
 		},


### PR DESCRIPTION
These adjustments are to accommodate the Fasta ID being generated App side for Rockhopper so that they can still be mapped to contig/replicon ID's.