### PR TITLE
fixing object selector > upload scroll issue

### DIFF
--- a/public/js/p3/widget/WorkspaceObjectSelector.js
+++ b/public/js/p3/widget/WorkspaceObjectSelector.js
@@ -327,7 +327,7 @@ define([
 			var backBC = new BorderContainer({
 				style: {
 					width: "805px",
-					height: "575px",
+					height: "700px",
 					margin: "0",
 					padding: "0px"
 				}
@@ -467,6 +467,10 @@ define([
 				this.dialog.backpaneTitleBar.innerHTML = "Upload files to Workspace";
 				var uploader = this.uploader = new Uploader({
 					path: _self.path,
+					style: {
+						height: "620px",
+						overflow: "scroll"
+					},
 					region: "center",
 					multiple: false,
 					types: this.type,


### PR DESCRIPTION
Issue was user may have to scroll to upload button when using the object selector version of upload:

![image](https://user-images.githubusercontent.com/1194246/31515247-19bdf798-af5a-11e7-8886-f512bcbf0640.png)
