### PR TITLE
newick file view. label search on tree ids

### DIFF
--- a/public/js/p3/widget/WorkspaceBrowser.js
+++ b/public/js/p3/widget/WorkspaceBrowser.js
@@ -470,8 +470,20 @@ define([
 			}, function(selection){
 				// console.log("View Experiment: ", selection[0]);
 				var expPath = this.get('path');
-				Topic.publish("/navigate", {href: "/view/PhylogeneticTree/?&wsTreeId=" + expPath});
+				Topic.publish("/navigate", {href: "/view/PhylogeneticTree/?&labelSearch=true&idType=genome_id&labelType=genome_name&wsTreeFolder=" + expPath});
 
+			}, false);
+
+
+			this.actionPanel.addAction("ViewNwk", "fa icon-tree2 fa-2x", {
+				label: "VIEW",
+				multiple: false,
+				validTypes: ["nwk"],
+				tooltip: "View Tree"
+			}, function(selection){
+				// console.log("View Experiment: ", selection[0]);
+				var path = selection.map(function(obj){ return obj.path });
+				Topic.publish("/navigate", {href: "/view/PhylogeneticTree/?&labelSearch=true&idType=genome_id&labelType=genome_name&wsTreeFile=" + path[0]});
 			}, false);
 
 

--- a/public/js/p3/widget/viewer/PhylogeneticTree.js
+++ b/public/js/p3/widget/viewer/PhylogeneticTree.js
@@ -2,11 +2,13 @@ define([
 	"dojo/_base/declare", "dojo/_base/lang",
 	"dojo/dom-construct", "dojo/request", "dojo/when",
 	"dijit/layout/ContentPane",
-	"./Base", "../../util/PathJoin", "../Phylogeny", "../../WorkspaceManager"
+	"./Base", "../../util/PathJoin", "../Phylogeny", "../../WorkspaceManager",
+    "dojo/request"
 ], function(declare, lang,
 			domConstruct, request, when,
 			ContentPane,
-			ViewerBase, PathJoin, Phylogeny, WorkspaceManager){
+			ViewerBase, PathJoin, Phylogeny, WorkspaceManager,
+            xhr){
 	return declare([ViewerBase], {
 		"disabled": false,
 		"query": null,
@@ -15,6 +17,7 @@ define([
 		perspectiveLabel: "Phylogenetic Tree",
 		perspectiveIconClass: "icon-selection-Experiment",
 		apiServiceUrl: window.App.dataAPI,
+		maxGenomesPerList: 10000,
 
 		onSetState: function(attr, oldVal, state){
 			// console.warn("TE onSetState", state);
@@ -89,9 +92,25 @@ define([
 			this.addChild(this.viewer);
 			this.inherited(arguments);
             var dataFiles = [];
-			var check = this.state.search.match(/wsTreeId=.*/);
-			if(check && !isNaN(check["index"])){
-                var objPathParts = check[0].split("=")[1].split("/");
+			var folderCheck = this.state.search.match(/wsTreeFolder=..+?(?=&|$)/);
+			var fileCheck = this.state.search.match(/wsTreeFile=..+?(?=&|$)/);
+			var idType = this.state.search.match(/idType=..+?(?=&|$)/);
+			var labelType = this.state.search.match(/labelType=..+?(?=&|$)/);
+            if(idType && !isNaN(idType["index"])){
+                idType = idType[0].split("=")[1];
+            }
+            else { idType = "genome_id";}
+            if(labelType && !isNaN(labelType["index"])){
+                labelType = labelType[0].split("=")[1];
+            }
+            else { labelType = "genome_name";}
+			var labelSearch = this.state.search.match(/labelSearch=.*/);
+            if(labelSearch && !isNaN(labelSearch["index"])){
+                labelSearch = labelSearch[0].split("=")[1];
+            }
+            else { labelSearch = false;}
+			if(folderCheck && !isNaN(folderCheck["index"])){
+                var objPathParts = folderCheck[0].split("=")[1].split("/");
                 var objName = objPathParts.pop();
                 this.displayName = decodeURIComponent(objName);
                 objName = "."+ objName;
@@ -113,12 +132,75 @@ define([
                                         treeDat = JSON.parse(curFiles[0].data);
                                         treeDat.info.taxon_name = _self.displayName;
                                     }
-                                    _self.viewer.processTreeData(treeDat);
+                                    _self.prepareTree(treeDat, idType, labelType, labelSearch);
                                 });
                         }
                 });
             }
+            else if(fileCheck && !isNaN(fileCheck["index"])){
+                var objPath = fileCheck[0].split("=")[1];
+			    WorkspaceManager.getObjects([objPath]).then(lang.hitch(this, function(objs){
+                    var obj = objs[0];
+                    var treeDat ={};
+				    if(typeof obj.data == 'string'){
+                        treeDat.tree = obj.data.replace(/[^(,)]+\_\@\_/g,""); //get rid of ridiculously annoying, super dirty embedded labels
+                        _self.prepareTree(treeDat, idType, labelType, labelSearch);
+                    }
+                }));
+            }
+		},
 
-		}
+        prepareTree: function(treeDat, idType, labelType, labelSearch){
+            if(labelSearch){
+                this.findLabels(treeDat, idType, labelType);
+            }
+            else{
+                this.viewer.processTreeData(treeDat);
+            }
+        },
+
+
+        findLabels: function(treeDat, idType, labelType){
+            _self = this;
+            var ids = treeDat.tree.match(/[^(,)]+(?=\:)/g);
+            var toQuery =[];
+            ids.forEach(function(id){
+                if(id.includes(".")){
+                    toQuery.push(id);
+                }
+            });
+
+            var query = "in("+idType+",("+toQuery.join(",")+"))";
+			var url = PathJoin(this.apiServiceUrl, "genome", "?" + (query) + "&select("+idType+","+labelType+")&limit(" + this.maxGenomesPerList + 1 + ")");
+
+			xhr.post(PathJoin(this.apiServiceUrl, "genome"), {
+				headers: {
+					accept: "application/solr+json",
+					'Content-Type': "application/rqlquery+x-www-form-urlencoded",
+					'X-Requested-With': null,
+					'Authorization': (window.App.authorizationToken || "")
+				},
+				handleAs: "json",
+				'Content-Type': "application/rqlquery+x-www-form-urlencoded",
+				data: (query) + "&select("+idType+","+labelType+")&limit(" + this.maxGenomesPerList + 1 + ")"
+
+			}).then(function(res){
+				//console.log(" URL: ", url);
+				// console.log("Get GenomeList Res: ", res);
+				if(res && res.response && res.response.docs){
+					var genomes = res.response.docs;
+                    treeDat.labels={};
+					genomes.forEach(function(genome){
+                        treeDat.labels[genome.genome_id]=genome.genome_name;
+                    });
+				}
+                else{
+					console.warn("Invalid Response for: ", url);
+				}
+                _self.viewer.processTreeData(treeDat);
+			}, function(err){
+				console.error("Error Retreiving Genomes: ", err);
+			});
+        }
 	});
 });


### PR DESCRIPTION
View a newick file individually from selection (and thus from upload).
Although not performant, or clean, or really desirable...regex IDs out of newick, run API to get labels. This is enabled by setting labelSearch=True. This is implemented to account for the missing labels upstream in tree building process.