### PR TITLE
prevent service submission when file upload is in progress

### DIFF
--- a/public/js/p3/widget/Uploader.js
+++ b/public/js/p3/widget/Uploader.js
@@ -344,16 +344,19 @@ define([
 				// only show prompt if given file-already-exists error
 				if (err.indexOf('overwrite flag is not set') === -1) return;
 
+				var def = new Deferred();
 				var conf = "Are you sure you want to overwrite <i>" + obj.path + obj.name + "</i> ?";
 				var dlg = new Confirmation({
 					title: "Overwriting File!",
 					content: conf,
 					onConfirm: function(evt){
-						_self.uploadFile(file, uploadDirectory, type, true)
+						_self.uploadFile(file, uploadDirectory, type, true);
+						def.resolve(obj);
 					}
 				});
 				dlg.startup();
 				dlg.show();
+				return def.promise;
 			});
 
 		},

--- a/public/js/p3/widget/WorkspaceObjectSelector.js
+++ b/public/js/p3/widget/WorkspaceObjectSelector.js
@@ -313,7 +313,7 @@ define([
 			var _self = this;
 
 			if(this.disabled){
-				new Dialog({title: "Notice", draggable: true, content: "Please wait until upload complete."}).show();
+				new Dialog({title: "Notice", draggable: true, content: "Please wait until upload completes."}).show();
 				return;
 			}
 			// if dialog is already built, just show it

--- a/public/js/p3/widget/WorkspaceObjectSelector.js
+++ b/public/js/p3/widget/WorkspaceObjectSelector.js
@@ -313,7 +313,7 @@ define([
 			var _self = this;
 
 			if(this.disabled){
-				new Dialog({title: "UPLOAD IN PROGRESS...", draggable: true, content: "Please wait until its completion."}).show();
+				new Dialog({title: "Notice", draggable: true, content: "Please wait until its completion."}).show();
 				return;
 			}
 			// if dialog is already built, just show it

--- a/public/js/p3/widget/WorkspaceObjectSelector.js
+++ b/public/js/p3/widget/WorkspaceObjectSelector.js
@@ -30,6 +30,7 @@ define([
 		promptMessage: "Please choose or upload a workspace item",
 		placeHolder: "",
 		allowUpload: true,  	    	// whether or not to add the upload button
+		uploadingSelection: "",     // uploading in progress, to be copied to selection
 		title: "Choose or Upload a Workspace Object",
 		autoSelectParent: false,   		// if true, the folder currently being viewed is selected by default
 		onlyWritable: false,	    	// only list writable workspaces
@@ -311,6 +312,10 @@ define([
 		openChooser: function(){
 			var _self = this;
 
+			if(this.disabled){
+				new Dialog({title: "UPLOAD IN PROGRESS...", draggable: true, content: "Please wait until its completion."}).show();
+				return;
+			}
 			// if dialog is already built, just show it
 			if(this.dialog){
 				this.dialog.flip("front");
@@ -482,8 +487,10 @@ define([
 					// console.log("Uploader Dialog Action: ", evt);
 					if(evt.files && evt.files[0] && evt.action == "close"){
 						var file = evt.files[0];
-						_self.set("selection", file);
-						_self.set('value', file.path, true);
+						//_self.set("selection", file);
+						//_self.set('value', file.path, true);
+						_self.set("disabled", true);
+						_self.set("uploadingSelection", file);
 						_self.dialog.hide();
 					}else{
 						_self.dialog.flip()
@@ -556,10 +563,26 @@ define([
 				this.refreshWorkspaceItems();
 			}
 			Topic.subscribe("/refreshWorkspace", lang.hitch(this, "refreshWorkspaceItems"));
+			Topic.subscribe("/upload", lang.hitch(this, "onUploadMessage"));
 			this.searchBox.set('disabled', this.disabled);
 			this.searchBox.set('required', this.required);
 			this.searchBox.set('placeHolder', this.placeHolder);
 			this.searchBox.labelFunc = this.labelFunc;
+		},
+
+		onUploadMessage(msg){
+			if(msg && msg.type == "UploadComplete"){
+				if(this.uploadingSelection != ""){
+					this.set("disabled", false);
+					this.set("selection", this.uploadingSelection);
+					if(msg.workspacePath.substr(-1) != '/'){
+						msg.workspacePath += '/';
+					}
+					this.set("value", msg.workspacePath+msg.filename);
+					this.set("uploadingSelection", "");
+				}
+			return;
+			}
 		},
 
 		labelFunc: function(item, store){

--- a/public/js/p3/widget/WorkspaceObjectSelector.js
+++ b/public/js/p3/widget/WorkspaceObjectSelector.js
@@ -313,7 +313,7 @@ define([
 			var _self = this;
 
 			if(this.disabled){
-				new Dialog({title: "Notice", draggable: true, content: "Please wait until its completion."}).show();
+				new Dialog({title: "Notice", draggable: true, content: "Please wait until upload complete."}).show();
 				return;
 			}
 			// if dialog is already built, just show it


### PR DESCRIPTION
There are several issues related to this fix, the main ones are: PATRIC3/patric3_webiste#1784 PATRIC3/patric3_webiste#1383

This requires some amount of testings as I modified how upload works in WorkspaceObjectSeletor. I have tested upload from Workspace, from UploadManager (bottom part of the page) and Assembly service. Also tested the logic in Annotation service (but I did not submit annotation job).