### PR TITLE
Features/new features

### DIFF
--- a/public/js/p3/widget/ActionBar.js
+++ b/public/js/p3/widget/ActionBar.js
@@ -18,15 +18,13 @@ define([
     currentContainerWidget: null,
     tooltipPosition: ['before', 'above'],
     _setCurrentContainerWidgetAttr: function (widget) {
-      // console.log("_set Current Container Widget: ", widget);
-      // console.log("_set CurrentContainerWidget: ", widget.containerType, widget, " Current: ", this.currentContainerWidget);
 
       if (widget.currentContainer === this.currentContainerWidget) {
         return;
       }
       this.currentContainerType = widget.containerType;
       this.currentContainerWidget = widget;
-      // console.log("CurrentContainerType: ", this.currentContainerType)
+
       this.set('selection', []);
     },
     _setSelectionAttr: function (sel) {
@@ -52,16 +50,14 @@ define([
             }
           }
         }
-        // console.log("Type: ", type);
+
         selectionTypes[type] = true;
       });
-      // console.log("selectionTypes: ", selectionTypes);
-      // console.log("_actions: ", this._actions);
+
       if (sel.length > 1) {
         var multiTypedSelection = (Object.keys(selectionTypes).length > 1);
-        // console.log("isMultiTyped: ", multiTypedSelection);
+
         valid = Object.keys(this._actions).filter(function (an) {
-          // console.log("Check action: ", an, this._actions[an].options);
           return this._actions[an] && this._actions[an].options &&
             (this._actions[an].options.multiple &&
             ((this._actions[an].options.ignoreDataType || !multiTypedSelection ||
@@ -94,8 +90,13 @@ define([
           }
         }
 
+        // allow kill job if any of the below
+        if (sel[0] && an === 'KillJob') {
+          if (['init', 'pending', 'queued', 'in-progress'].indexOf(sel[0].status) == -1) return false;
+        }
+
         // if top level "workspace", hide actions
-        if (sel[0] && 'isWorkspace' in sel[0] && ['CreateFolder', 'Upload', 'ShowHidden'].indexOf(an) !== -1) {
+        else if (sel[0] && 'isWorkspace' in sel[0] && ['CreateFolder', 'Upload', 'ShowHidden'].indexOf(an) !== -1) {
           return false;
         }
 
@@ -131,9 +132,6 @@ define([
         var validContainerTypes = act.options.validContainerTypes || null;
 
         if (validContainerTypes) {
-          // console.log("checkValidContainerTypes", validContainerTypes);
-          // console.log("Current ContainerType: ", this.currentContainerType);
-          // console.log("Current Container Widget: ", this.currentContainerWidget);
           if (!validContainerTypes.some(function (t) {
             return ((t == '*') || (t == this.currentContainerType));
           }, this)) {

--- a/public/js/p3/widget/JobManager.js
+++ b/public/js/p3/widget/JobManager.js
@@ -1,12 +1,12 @@
 define([
-  'dojo/_base/declare', 'dijit/_WidgetBase', 'dojo/on', 'dojo/_base/lang',  'dojo/query',
+  'dojo/_base/declare', 'dojo/on', 'dojo/_base/lang',  'dojo/query',
   'dojo/dom-class', 'dojo/dom-attr', 'dojo/dom-construct', './JobsGrid', './JobContainerActionBar',
-  'dojo/_base/Deferred', 'dojo/dom-geometry', '../JobManager',
+  'dojo/_base/Deferred', '../JobManager', './Confirmation',
   'dojo/topic', 'dijit/layout/BorderContainer', './ActionBar', './ItemDetailPanel'
 ], function (
-  declare, WidgetBase, on, lang, query,
+  declare, on, lang, query,
   domClass, domAttr, domConstr, JobsGrid, JobContainerActionBar,
-  Deferred, domGeometry, JobManager,
+  Deferred, JobManager, Confirmation,
   Topic, BorderContainer, ActionBar, ItemDetailPanel
 ) {
   return declare([BorderContainer], {
@@ -89,6 +89,36 @@ define([
         function (selection) {
           var sel = selection[0];
           Topic.publish('/navigate', { href: '/workspace' + sel.parameters.output_path + '/' + sel.parameters.output_file });
+        },
+        false
+      ], [
+        'KillJob',
+        'MultiButton fa icon-ban fa-2x',
+        {
+          label: 'KILL JOB',
+          validTypes: ['*'],
+          multiple: false,
+          tooltip: 'Kill (Cancel) Selected Job',
+          validContainerTypes: ['*']
+        },
+        function (selection) {
+          var sel = selection[0],
+            id = sel.id;
+
+          var conf = 'Are you sure you want to terminate this ' + sel.app + ' job?<br><br>' +
+                     '<b>Job ID</b>: ' + id + '<br><br>';
+
+          var dlg = new Confirmation({
+            title: 'Delete Job',
+            content: conf,
+            style: { width: '375px' },
+            onConfirm: function (evt) {
+              JobManager.killJob(id);
+            }
+          });
+          dlg.startup();
+          dlg.show();
+
         },
         false
       ], [

--- a/public/js/p3/widget/WorkspaceObjectSelector.js
+++ b/public/js/p3/widget/WorkspaceObjectSelector.js
@@ -178,7 +178,10 @@ define([
       return this.searchBox.get('value', value);
     },
 
+    // sets selection of object selector form field
     _setSelectionAttr: function (val) {
+      // allowing object selector to be used without form
+      if (!val) return;
 
       this.selection = val;
       // ensures item is in store (for public workspaces),

--- a/public/js/p3/widget/formatter.js
+++ b/public/js/p3/widget/formatter.js
@@ -338,7 +338,7 @@ define(
         else if (val == 'in-progress')
         { return '<b style="color: #ffa900;" title="Running">running</b>'; }
         else if (val == 'deleted' || val == 'failed')
-        { return '<b style="color: #a94442" title="Failed">failed</b>'; }
+        { return '<b style="color: #a94442" title="Failed">' + val + '</b>'; }
         else if (val == 'completed')
         { return '<b style="color: #3c763d;" title="Completed">completed</b>'; }
         return val;


### PR DESCRIPTION
This adds a "kill job" button to the job page.  Users can terminate any job that is in "init", "pending", "queued", or "in-progress".  On the backend, the terminated job is simply marked as "deleted".   This PR also filters out "deleted" jobs from the UI.