### PR TITLE
Features/new features

### DIFF
--- a/public/js/p3/widget/WorkspaceBrowser.js
+++ b/public/js/p3/widget/WorkspaceBrowser.js
@@ -768,7 +768,8 @@ define([
         // open object selector to get destination
         var objSelector = new WSObjectSelector({
           allowUpload: false,
-          autoSelectParent: true,
+          autoSelectCurrent: true,
+          allowUserSpaceSelection: true,
           onlyWritable: true,
           selectionText: 'Destination'
         });
@@ -844,7 +845,8 @@ define([
         // open object selector to get destination
         var objSelector = new WSObjectSelector({
           allowUpload: false,
-          autoSelectParent: true,
+          autoSelectCurrent: true,
+          allowUserSpaceSelection: true,
           onlyWritable: true,
           selectionText: 'Destination'
         });

--- a/public/js/p3/widget/WorkspaceObjectSelector.js
+++ b/public/js/p3/widget/WorkspaceObjectSelector.js
@@ -199,7 +199,7 @@ define([
       this.selection = val;
 
       // need to ensure item is in store (for public workspaces),
-      // this is more  thefficientan recursively grabing all public objects of a certain type
+      // this is more efficient than recursively grabing all public objects of a certain type
       if (this.selection !== '*none*') {
         try {
           this.store.add(this.selection);

--- a/public/js/p3/widget/WorkspaceObjectSelector.js
+++ b/public/js/p3/widget/WorkspaceObjectSelector.js
@@ -62,12 +62,9 @@ define([
       }
     },
     sortAlpha: function () {
-      // console.log('sort me');
+      // but, isSortAlpha is never set to false
+      // it should be possible to toggle instead
       this.isSortAlpha = true;
-      // var wos = document.getElementsByClassName('WorkspaceObjectSelector')[0];
-      // console.log(wos);
-      // console.log(window.App);
-      // console.log(window);
       this.refreshWorkspaceItems();
     },
     _setShowHiddenAttr: function (val) {
@@ -162,6 +159,8 @@ define([
       this.cancelRefresh();
       this.refreshWorkspaceItems();
     },
+
+    // sets value of object selector dropdown
     _setValueAttr: function (value, refresh) {
       this.value = value;
       if (this._started) {
@@ -184,7 +183,8 @@ define([
       if (!val) return;
 
       this.selection = val;
-      // ensures item is in store (for public workspaces),
+
+      // need to ensure item is in store (for public workspaces),
       // this is more efficient than recursively grabing all public objects of a certain type
       try {
         this.store.add(this.selection);
@@ -488,7 +488,6 @@ define([
         });
 
         on(uploader.domNode, 'dialogAction', function (evt) {
-          // console.log("Uploader Dialog Action: ", evt);
           if (evt.files && evt.files[0] && evt.action == 'close') {
             var file = evt.files[0];
             _self.set('selection', file);
@@ -539,7 +538,7 @@ define([
       this._refreshing = WorkspaceManager.getObjectsByType(this.type, true)
         .then(lang.hitch(this, function (items) {
           delete this._refreshing;
-          // console.log('am i here?');
+
           // sort by most recent
           items.sort(function (a, b) {
             return b.timestamp - a.timestamp;
@@ -547,10 +546,9 @@ define([
           this.store = new Memory({ data: items, idProperty: 'path' });
           if (this.isSortAlpha) {
             // sort alphabetically
-            // console.log(this.store.data);
             var dataArr = this.store.data;
             dataArr.sort(compare);
-            // console.log(dataArr);
+
             this.store.data = dataArr;
           }
           this.searchBox.set('store', this.store);
@@ -574,7 +572,7 @@ define([
       if (this._started) {
         return;
       }
-      // console.log("call getObjectsByType(); ", this.type);
+
       this.inherited(arguments);
 
       var _self = this;
@@ -591,7 +589,7 @@ define([
       this.searchBox.set('required', this.required);
       this.searchBox.set('placeHolder', this.placeHolder);
       this.searchBox.labelFunc = this.labelFunc;
-      // console.log(this.searchBox);
+
       // window.App.refreshSelector = this.refreshWorkspaceItems;
     },
 
@@ -730,12 +728,10 @@ define([
 
       grid.on('ItemDblClick', function (evt) {
         if (evt.item && evt.item.type == 'folder' || evt.item.type == 'parentfolder') {
-          self.set('path', evt.item_path);
+          self.set('path', evt.item.path);
         } else {
-          if (self.selection) {
-            self.set('value', self.selection.path);
-            self.dialog.hide();
-          }
+          self.set('value', evt.item.path);
+          self.dialog.hide();
         }
       });
 

--- a/public/js/p3/widget/app/templates/Annotation.html
+++ b/public/js/p3/widget/app/templates/Annotation.html
@@ -83,7 +83,8 @@
         <div class="appRow">
           <div class="appFieldLong">
             <label>Output Folder</label><br>
-            <div data-dojo-attach-point="output_pathWidget" data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" style="width:100%" required="true" data-dojo-props="type:['folder'],multi:false,value:'${activeWorkspacePath}',workspace:'${activeWorkspace}',promptMessage:'The output folder for your Annotation Results',missingMessage:'Output Folder must be selected.'"
+            <div data-dojo-attach-point="output_pathWidget" data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" style="width:100%" required="true"
+              data-dojo-props="title:'Select an Output Folder',autoSelectCurrent:true,type:['folder'],multi:false,value:'${activeWorkspacePath}',workspace:'${activeWorkspace}',promptMessage:'The output folder for your Annotation Results',missingMessage:'Output Folder must be selected.'"
             data-dojo-attach-event="onChange:onOutputPathChange"></div>
           </div>
         </div>

--- a/public/js/p3/widget/app/templates/Assembly.html
+++ b/public/js/p3/widget/app/templates/Assembly.html
@@ -151,7 +151,8 @@
               </div>
               <div class="appRow">
                 <label class="paramlabel">Output Folder</label><br>
-                <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" data-dojo-attach-point="output_path" style="width:300px" required="true" data-dojo-props="type:['folder'],multi:false" data-dojo-attach-event="onChange:onOutputPathChange"></div>
+                <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" data-dojo-attach-point="output_path" style="width:300px" required="true"
+                  data-dojo-props="title:'Select an Output Folder',autoSelectCurrent:true,selectionText:'Destination',title:'Select an Output Folder',type:['folder'],multi:false" data-dojo-attach-event="onChange:onOutputPathChange"></div>
               </div>
               <div class="appRow">
                 <label class="paramlabel">Output Name</label><span class="charError" style="color:red; font-size:8pt; padding-left:10px; font-weight:bold">&nbsp;</span><br>

--- a/public/js/p3/widget/app/templates/ComprehensiveGenomeAnalysis.html
+++ b/public/js/p3/widget/app/templates/ComprehensiveGenomeAnalysis.html
@@ -184,7 +184,7 @@
         </div>
         <div class="appRow">
           <label class="paramlabel">Output Folder</label><br>
-          <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" data-dojo-attach-point="output_path" style="width:300px" required="true" data-dojo-props="type:['folder'],multi:false" data-dojo-attach-event="onChange:onOutputPathChange"></div>
+          <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" data-dojo-attach-point="output_path" style="width:300px" required="true" data-dojo-props="title:'Select an Output Folder',autoSelectCurrent:true,selectionText:'Destination',type:['folder'],multi:false" data-dojo-attach-event="onChange:onOutputPathChange"></div>
         </div>
         <div class="appRow">
           <div class="appFieldLong" style="width:380px">

--- a/public/js/p3/widget/app/templates/Expression.html
+++ b/public/js/p3/widget/app/templates/Expression.html
@@ -140,7 +140,7 @@
                                 <div data-dojo-attach-point="output_pathWidget"
                                      data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path"
                                      style="width:100%" required="true"
-                                     data-dojo-props="type:['folder'],multi:false,value:'${activeWorkspacePath}',workspace:'${activeWorkspace}',promptMessage:'The output folder for your Annotation Results',missingMessage:'Output Folder must be selected.'"
+                                     data-dojo-props="title:'Select an Output Folder',autoSelectCurrent:true,selectionText:'Destination',type:['folder'],multi:false,value:'${activeWorkspacePath}',workspace:'${activeWorkspace}',promptMessage:'The output folder for your Annotation Results',missingMessage:'Output Folder must be selected.'"
                                      data-dojo-attach-event="onChange:onOutputPathChange"></div>
                             </div>
 

--- a/public/js/p3/widget/app/templates/MetagenomeBinning.html
+++ b/public/js/p3/widget/app/templates/MetagenomeBinning.html
@@ -81,7 +81,7 @@
               </div>
               <div class="appRow">
                 <label class="paramlabel">Output Folder</label><br>
-                <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" data-dojo-attach-point="output_path" style="width:300px" required="true" data-dojo-props="type:['folder'],multi:false" data-dojo-attach-event="onChange:validate"></div>
+                <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" data-dojo-attach-point="output_path" style="width:300px" required="true" data-dojo-props="title:'Select an Output Folder',autoSelectCurrent:true,selectionText:'Destination',type:['folder'],multi:false" data-dojo-attach-event="onChange:validate"></div>
               </div>
               <div class="appRow">
                 <label class="paramlabel">Output Name</label><span class="charError" style="color:red; font-size:8pt; padding-left:10px; font-weight:bold">&nbsp;</span><br>

--- a/public/js/p3/widget/app/templates/PhylogeneticTree.html
+++ b/public/js/p3/widget/app/templates/PhylogeneticTree.html
@@ -78,7 +78,7 @@
 
                     <div class="appRow">
                       <label class="paramlabel">Output Folder</label><br>
-                      <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" data-dojo-attach-point="output_path" required="true" data-dojo-props="type:['folder'],multi:false" data-dojo-attach-event="onChange:onOutputPathChange"></div>
+                      <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" data-dojo-attach-point="output_path" required="true" data-dojo-props="title:'Select an Output Folder',autoSelectCurrent:true,selectionText:'Destination',type:['folder'],multi:false" data-dojo-attach-event="onChange:onOutputPathChange"></div>
                     </div>
                     <div class="appRow">
                       <label class="paramlabel">Output Name</label><span class="charError" style="color:red; font-size:8pt; padding-left:10px; font-weight:bold">&nbsp;</span><br>

--- a/public/js/p3/widget/app/templates/Reconstruct.html
+++ b/public/js/p3/widget/app/templates/Reconstruct.html
@@ -81,7 +81,7 @@
         <div class="appRow">
           <div class="appField">
             <label>Output Folder</label>
-            <div data-dojo-attach-point="output_pathWidget" data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" style="width:100%" required="true" data-dojo-props="type:['folder'],multi:false,value:'${activeWorkspacePath}',workspace:'${activeWorkspace}',promptMessage:'The output folder for your Reconstruction Results',missingMessage:'Output Folder must be selected.'"
+            <div data-dojo-attach-point="output_pathWidget" data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" style="width:100%" required="true" data-dojo-props="title:'Select an Output Folder',autoSelectCurrent:true,selectionText:'Destination',type:['folder'],multi:false,value:'${activeWorkspacePath}',workspace:'${activeWorkspace}',promptMessage:'The output folder for your Reconstruction Results',missingMessage:'Output Folder must be selected.'"
               data-dojo-attach-event="onChange:onOutputPathChange"></div>
             <label>Output Name</label><span class="charError" style="color:red; font-size:8pt; padding-left:10px; font-weight:bold">&nbsp;</span><br>
             <div data-dojo-type="p3/widget/WorkspaceFilenameValidationTextBox" data-dojo-attach-event="onChange:checkOutputName" name="output_file" data-dojo-attach-point="output_file" style="width:85%" required="true" data-dojo-props="intermediateChanges:true,missingMessage:'Name must be provided for the job result',trim:true,placeHolder:'Output Name'"></div>

--- a/public/js/p3/widget/app/templates/Rnaseq.html
+++ b/public/js/p3/widget/app/templates/Rnaseq.html
@@ -50,7 +50,7 @@
               </div>
               <div class="appRow">
                 <label class="paramlabel">Output Folder</label><br>
-                <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" data-dojo-attach-point="output_path" style="width:300px" required="true" data-dojo-props="type:['folder'],multi:false" data-dojo-attach-event="onChange:onOutputPathChange"></div>
+                <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" data-dojo-attach-point="output_path" style="width:300px" required="true" data-dojo-props="title:'Select an Output Folder',autoSelectCurrent:true,selectionText:'Destination',type:['folder'],multi:false" data-dojo-attach-event="onChange:onOutputPathChange"></div>
               </div>
               <div class="appRow">
                 <label class="paramlabel">Output Name</label><span class="charError" style="color:red; font-size:8pt; padding-left:10px; font-weight:bold">&nbsp;</span><br>

--- a/public/js/p3/widget/app/templates/SeqComparison.html
+++ b/public/js/p3/widget/app/templates/SeqComparison.html
@@ -61,7 +61,7 @@
                     </div>
                     <div class="appRow">
                       <label class="paramlabel">Output Folder</label><br>
-                      <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" data-dojo-attach-point="output_path" required="true" data-dojo-props="type:['folder'],multi:false" data-dojo-attach-event="onChange:onOutputPathChange"></div>
+                      <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" data-dojo-attach-point="output_path" required="true" data-dojo-props="title:'Select an Output Folder',autoSelectCurrent:true,selectionText:'Destination',type:['folder'],multi:false" data-dojo-attach-event="onChange:onOutputPathChange"></div>
                     </div>
                     <div class="appRow">
                       <label class="paramlabel">Output Name</label><span class="charError" style="color:red; font-size:8pt; padding-left:10px; font-weight:bold">&nbsp;</span><br>

--- a/public/js/p3/widget/app/templates/SimpleAnnotation.html
+++ b/public/js/p3/widget/app/templates/SimpleAnnotation.html
@@ -59,7 +59,7 @@
         <div class="appRow">
           <div class="appField">
             <label>Output Folder</label><br>
-            <div data-dojo-attach-point="output_pathWidget" data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" style="width:100%" required="true" data-dojo-props="type:['folder'],multi:false,value:'${activeWorkspacePath}',workspace:'${activeWorkspace}',promptMessage:'The output folder for your Annotation Results',missingMessage:'Output Folder must be selected.'"
+            <div data-dojo-attach-point="output_pathWidget" data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" style="width:100%" required="true" data-dojo-props="title:'Select an Output Folder',autoSelectCurrent:true,selectionText:'Destination',type:['folder'],multi:false,value:'${activeWorkspacePath}',workspace:'${activeWorkspace}',promptMessage:'The output folder for your Annotation Results',missingMessage:'Output Folder must be selected.'"
               data-dojo-attach-event="onChange:onOutputPathChange"></div>
           </div>
         </div>

--- a/public/js/p3/widget/app/templates/Tnseq.html
+++ b/public/js/p3/widget/app/templates/Tnseq.html
@@ -47,7 +47,7 @@
               </div>
               <div class="appRow">
                 <label class="paramlabel">Output Folder</label><br>
-                <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" data-dojo-attach-point="output_path" style="width:300px" required="true" data-dojo-props="type:['folder'],multi:false" data-dojo-attach-event="onChange:onOutputPathChange"></div>
+                <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" data-dojo-attach-point="output_path" style="width:300px" required="true" data-dojo-props="title:'Select an Output Folder',autoSelectCurrent:true,selectionText:'Destination',type:['folder'],multi:false" data-dojo-attach-event="onChange:onOutputPathChange"></div>
               </div>
               <div class="appRow">
                 <label class="paramlabel">Output Name</label><span class="charError" style="color:red; font-size:8pt; padding-left:10px; font-weight:bold">&nbsp;</span><br>

--- a/public/js/p3/widget/app/templates/Variation.html
+++ b/public/js/p3/widget/app/templates/Variation.html
@@ -113,7 +113,7 @@
               </div>
               <div class="appRow">
                 <label class="paramlabel">Output Folder</label><br>
-                <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" data-dojo-attach-point="output_path" style="width:300px" required="true" data-dojo-props="type:['folder'],multi:false" data-dojo-attach-event="onChange:onOutputPathChange"></div>
+                <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="output_path" data-dojo-attach-point="output_path" style="width:300px" required="true" data-dojo-props="title:'Select an Output Folder',autoSelectCurrent:true,selectionText:'Destination',type:['folder'],multi:false" data-dojo-attach-event="onChange:onOutputPathChange"></div>
               </div>
               <div class="appRow">
                 <label class="paramlabel">Output Name</label><span class="charError" style="color:red; font-size:8pt; padding-left:10px; font-weight:bold">&nbsp;</span><br>


### PR DESCRIPTION
I could use help testing this when it's on alpha.  In particular, @dawenx and @olsonanl are aware of most of the issues this fixes.  It affects all apps.

This is all things related to the object selector:

- fixes object selector double click issue
- fixes icon selection issue
- auto-select the currently viewed folder when selecting output folders
- allow workspace-level selection when needed (move/copy) 
- disable the OK button when needed
- change output folder dialog titles / UX things
