### PR TITLE
fix bug in group selector

### DIFF
--- a/public/js/p3/widget/WorkspaceObjectSelector.js
+++ b/public/js/p3/widget/WorkspaceObjectSelector.js
@@ -97,6 +97,8 @@ define([
 
     // sets path, which is used for the dialog state (not for the dropbox)
     _setPathAttr: function (val) {
+      if (!val) return; // for group selection (hacky)
+
       var self = this;
 
       // remove trailing '/' in path for consistency


### PR DESCRIPTION
The group dialog was initializing the path to undefined, so needed to ignore that 'setPath'