### PR TITLE
Navigation fixes and console error suppression

### DIFF
--- a/public/js/p3/app/app.js
+++ b/public/js/p3/app/app.js
@@ -281,7 +281,7 @@ define([
       /* istanbul ignore next */
       on(window, 'message', function (msg) {
         // console.log('onMessage: ', msg);
-        if (msg && msg.data === 'RemoteReady') {
+        if (msg && (msg.data === 'RemoteReady' || !msg.data)) {
           return;
         }
         msg = JSON.parse(msg.data);

--- a/public/js/p3/router.js
+++ b/public/js/p3/router.js
@@ -72,7 +72,7 @@ define(['dojo/_base/declare', 'dojo/router/RouterBase'
         window.history.pushState(state || {}, 'route', href);
         this._handlePathChange(href, state || {});
       } else if (state) {
-        window.history.replaceState(state || {}, "route", href);
+        window.history.replaceState(state || {}, 'route', href);
       }
     },
 

--- a/public/js/p3/router.js
+++ b/public/js/p3/router.js
@@ -72,9 +72,7 @@ define(['dojo/_base/declare', 'dojo/router/RouterBase'
         window.history.pushState(state || {}, 'route', href);
         this._handlePathChange(href, state || {});
       } else if (state) {
-        window.history.replaceState(state || {});
-        // I would like to change the above method to the following in a separate PR
-        // window.history.replaceState(state || {}, "route", href);
+        window.history.replaceState(state || {}, "route", href);
       }
     },
 

--- a/public/js/p3/widget/JobManager.js
+++ b/public/js/p3/widget/JobManager.js
@@ -211,6 +211,13 @@ define([
 
       this.setupActions();
 
+      this.grid.on('ItemDblClick', lang.hitch(this, function (evt) {
+        // console.log('JobManager.ItemDblClick', evt);
+        if (evt.selected) {
+          Topic.publish('/navigate', { href: '/workspace' + evt.selected.parameters.output_path + '/' + evt.selected.parameters.output_file });
+        }
+      }));
+
       this.grid.on('select', lang.hitch(this, function (evt) {
         var sel = Object.keys(evt.selected).map(lang.hitch(this, function (rownum) {
           var d = evt.grid.row(rownum).data;

--- a/public/js/p3/widget/JobsGrid.js
+++ b/public/js/p3/widget/JobsGrid.js
@@ -192,7 +192,7 @@ define(
 
         this.on('.dgrid-content .dgrid-row:dblclick', function (evt) {
           var row = _self.row(evt);
-          console.log('JobsGrid:dblclick: ', row)
+          // console.log('JobsGrid:dblclick: ', row);
 
           on.emit(_self.domNode, 'ItemDblClick', {
             selected: row.data,

--- a/public/js/p3/widget/JobsGrid.js
+++ b/public/js/p3/widget/JobsGrid.js
@@ -190,6 +190,17 @@ define(
           on.emit(_self.domNode, 'deselect', newEvt);
         });
 
+        this.on('.dgrid-content .dgrid-row:dblclick', function (evt) {
+          var row = _self.row(evt);
+          console.log('JobsGrid:dblclick: ', row)
+
+          on.emit(_self.domNode, 'ItemDblClick', {
+            selected: row.data,
+            bubbles: true,
+            cancelable: true
+          });
+        });
+
         this.refresh();
 
       }

--- a/public/js/p3/widget/WorkspaceBrowser.js
+++ b/public/js/p3/widget/WorkspaceBrowser.js
@@ -371,6 +371,18 @@ define([
 
       }, false);
 
+      // XXX WIP
+      // this.actionPanel.addAction('ViewAnnotatedGenome', 'fa icon-eye fa-2x', {
+      //   label: 'VIEW',
+      //   multiple: false,
+      //   validTypes: ['GenomeAnnotation', 'GenomeAnnotationGenbank'],
+      //   tooltip: 'View Annotated Genome'
+      // }, function (selection) {
+      //   console.log("View Annotated Genome selection: ", selection);
+      //   var gid = selection[0].reference_genome_id;
+      //   Topic.publish('/navigate', { href: '/view/Genome/' + gid });
+      // }, false);
+
       this.browserHeader.addAction('ViewModel', 'fa icon-eye fa-2x', {
         label: 'VIEW <i class="icon-external-link"></i>',
         multiple: false,
@@ -1304,7 +1316,9 @@ define([
                   Topic.publish('/navigate', { href: '/workspace' + evt.item_path });
                   this.actionPanel.set('selection', []);
                   this.itemDetailPanel.set('selection', []);
-                  newPanel.clearSelection();
+                  if ('clearSelection' in newPanel) {
+                      newPanel.clearSelection();
+                  }
                 } else {
                   console.log('non-navigable type, todo: show info panel when dblclick');
                 }

--- a/public/js/p3/widget/WorkspaceBrowser.js
+++ b/public/js/p3/widget/WorkspaceBrowser.js
@@ -1315,7 +1315,7 @@ define([
                 this.actionPanel.set('selection', []);
                 this.itemDetailPanel.set('selection', []);
                 if ('clearSelection' in newPanel) {
-                    newPanel.clearSelection();
+                  newPanel.clearSelection();
                 }
               } else {
                 console.log('non-navigable type, todo: show info panel when dblclick');

--- a/public/js/p3/widget/WorkspaceBrowser.js
+++ b/public/js/p3/widget/WorkspaceBrowser.js
@@ -532,7 +532,7 @@ define([
         validTypes: ['RNASeq', 'TnSeq', 'Variation'],
         tooltip: 'View tracks in genome browser.'
       }, function (selection) {
-        // console.log("View Tracks: ", selection[0]);
+        // console.log("View Tracks: ", this);
         var genomeId = self.actionPanel.currentContainerWidget.getGenomeId();
         var urlQueryParams = self.actionPanel.currentContainerWidget.getJBrowseURLQueryParams();
         Topic.publish('/navigate', { href: '/view/Genome/' + genomeId + '#' + urlQueryParams });

--- a/public/js/p3/widget/viewer/Seq.js
+++ b/public/js/p3/widget/viewer/Seq.js
@@ -1,7 +1,7 @@
 define([
   'dojo/_base/declare', './JobResult', '../../WorkspaceManager',
-  'dojo/_base/Deferred', 'dojo/_base/lang'
-], function (declare, JobResult, WS, Deferred, lang) {
+  'dojo/_base/Deferred', 'dojo/_base/lang', 'dojo/query', 'dojo/dom-attr'
+], function (declare, JobResult, WS, Deferred, lang, query, domAttr) {
   return declare([JobResult], {
     containerType: 'Seq',
     streamables: null,
@@ -15,6 +15,12 @@ define([
       this.urls = [];
       this.jbrowseUrl;
       var _self = this;
+
+      this.button = query('.icon-genome-browser')[0];
+      // domClass.toggle(this.button, 'disabled');
+      // domAttr.set(this.button, 'disabled', true);
+      // console.log('[JobResult.Seq] this.button: (disabled) ', this.button);
+
       this.getDownloadUrlsForFiles().then(function (objs) {
         _self.getJBrowseURLQueryParams();
       });
@@ -195,6 +201,10 @@ define([
         + '&tracks=PATRICGenes,RefSeqGenes';
 
       // console.log("[Seq] url params: ", this.jbrowseUrl);
+      // domClass.toggle(this.button, 'disabled');
+      // domAttr.set(this.button, 'disabled', false);
+      // console.log('[JobResult.Seq] this.button: (enabled) ', this.button);
+
       return this.jbrowseUrl;
     }
   });


### PR DESCRIPTION
There are four changes bundled in this PR:

1) In app.js, the addition of a check for no msg.data suppresses console errors from the subsequent JSON.parse call.

2) Uncommented a previous dev's suggestion on fixing the replaceState call to remove console errors that occur when using the back button between workspace browser pages. (It was complaining that there was only one argument for that method.)

3) Removed the checks for whether the panel is an instance of Panel in the WorkspaceBrowser because it was preventing users from navigating from one job result into a child job result.  In general, it seemed to be causing issues using the back button.

4) Added a double click event to jobs in the job grid so users can just double click on the job to see its results instead of having to highlight and then click the 'eye' icon.