### PR TITLE
revert a float

### DIFF
--- a/public/js/p3/resources/WorkspaceManager.css
+++ b/public/js/p3/resources/WorkspaceManager.css
@@ -341,6 +341,7 @@ th.dgrid-cell.wsItemMembers {
 }
 
 .wsActionContainer {
+	float: right;
 	white-space: nowrap;  /* don't wrap icons */
 }
 


### PR DESCRIPTION
Despite checking, I didn't realize this float was being used elsewhere, such as the heatmap. 

https://github.com/PATRIC3/p3_web/pull/862/commits/f48b7fd6b0aa2ffdec01dc2ce3af9abefe509183#diff-fb74d4c29c5b4b9fca0c04b41efc9f52L339