### PR TITLE
exclude rql/js-array from build profile

### DIFF
--- a/public/js/release.profile.js
+++ b/public/js/release.profile.js
@@ -88,7 +88,8 @@ var profile = {
         'dijit/ToolbarSeparator',
         'p3/widget/ProteinFeatureSummary',
         'jDataView'
-      ]
+      ],
+      exclude: ["rql/js-array"]
     },
     'p3/layer/panels': {
       include: [
@@ -97,7 +98,8 @@ var profile = {
         'p3/widget/Uploader'
       ],
       exclude: [
-        'p3/layer/core'
+        'p3/layer/core',
+	'rql/js-array'
       ]
     },
     'p3/layer/p3user': {
@@ -114,7 +116,8 @@ var profile = {
         'dijit/selection',
         'dijit/form/ComboButton',
         'dijit/form/ToggleButton'
-      ]
+      ],
+      exclude: ['rql/js-array']
     },
     'p3/layer/globalWSObject': {
       customBase: true,
@@ -122,6 +125,7 @@ var profile = {
       include: [
         'p3/GlobalWorkspace'
       ],
+      exclude: ['rql/js-array'],
       deps: [
         'p3/GlobalWorkspace'
       ]


### PR DESCRIPTION
This pr excludes rql/js-array from the build profile.  In my local testing this appears to resolve the download issue for #1939 and maybe one of the other download links.  Please let me know when this has been deployed on the dev server so that I can do some additional testing.