### PR TITLE
Duplicate EC Numbers & Pathways

### DIFF
--- a/public/js/p3/widget/FeatureOverview.js
+++ b/public/js/p3/widget/FeatureOverview.js
@@ -327,42 +327,42 @@ define([
       var tbodyQuery = domQuery('table.p3basic > tbody', this.functionalPropertiesNode);
       var tbody = tbodyQuery[0];
 
-      var ecNum = data.map(function(el) {
+      var ecNum = data.map(function (el) {
         return el.ec_number;
       });
       var ecNumber = Array.from(new Set(ecNum));
 
-      var ecDesc = data.map(function(el) {
+      var ecDesc = data.map(function (el) {
         return el.ec_description;
       });
       var ecDescription = Array.from(new Set(ecDesc));
 
-      var ecLink = "";
+      var ecLink = '';
       for (var i = 0; i < ecNumber.length; i++) {
         ecLink = ecLink += '<a href="http://enzyme.expasy.org/EC/' + ecNumber[i] + '" target=_blank>' + ecNumber[i] + '</a>&nbsp;' + ecDescription[i] + '<br>';
       }
 
-      var genID = data.map(function(el) {
+      var genID = data.map(function (el) {
         return el.genome_id;
-      })
+      });
       var genomeID = Array.from(new Set(genID));
 
-      var pathID = data.map(function(el) {
+      var pathID = data.map(function (el) {
         return el.pathway_id;
-      })
+      });
       var pathwayID = Array.from(new Set(pathID));
 
-      var featID = data.map(function(el) {
+      var featID = data.map(function (el) {
         return el.feature_id;
-      })
+      });
       var featureID = Array.from(new Set(featID));
 
-      var pathName = data.map(function(el) {
+      var pathName = data.map(function (el) {
         return el.pathway_name;
-      })
+      });
       var pathwayName = Array.from(new Set(pathName));
 
-      var pwLink = "";
+      var pwLink = '';
       for (var i = 0; i < pathwayID.length; i++) {
         pwLink = pwLink += '<a href="/view/PathwayMap/?annotation=PATRIC&genome_id=' + genomeID[i] + '&pathway_id=' + pathwayID[i] + '&feature_id=' + featureID[i] + '" target="_blank">KEGG:' + pathwayID[i] + '</a>&nbsp;' + pathwayName[i] + '<br>';
       }

--- a/public/js/p3/widget/FeatureOverview.js
+++ b/public/js/p3/widget/FeatureOverview.js
@@ -327,13 +327,6 @@ define([
       var tbodyQuery = domQuery('table.p3basic > tbody', this.functionalPropertiesNode);
       var tbody = tbodyQuery[0];
 
-      var pwLink;
-      if (data) {
-        pwLink = data.map(function (row) {
-          return '<a href="/view/PathwayMap/?annotation=PATRIC&genome_id=' + row.genome_id + '&pathway_id=' + row.pathway_id + '&feature_id=' + row.feature_id + '" target="_blank">KEGG:' + row.pathway_id + '</a>&nbsp;' + row.pathway_name;
-        }).join('<br>');
-      }
-
       var ecNum = data.map(function(el) {
         return el.ec_number;
       });
@@ -347,6 +340,31 @@ define([
       var ecLink = "";
       for (var i = 0; i < ecNumber.length; i++) {
         ecLink = ecLink += '<a href="http://enzyme.expasy.org/EC/' + ecNumber[i] + '" target=_blank>' + ecNumber[i] + '</a>&nbsp;' + ecDescription[i] + '<br>';
+      }
+
+      var genID = data.map(function(el) {
+        return el.genome_id;
+      })
+      var genomeID = Array.from(new Set(genID));
+
+      var pathID = data.map(function(el) {
+        return el.pathway_id;
+      })
+      var pathwayID = Array.from(new Set(pathID));
+
+      var featID = data.map(function(el) {
+        return el.feature_id;
+      })
+      var featureID = Array.from(new Set(featID));
+
+      var pathName = data.map(function(el) {
+        return el.pathway_name;
+      })
+      var pathwayName = Array.from(new Set(pathName));
+
+      var pwLink = "";
+      for (var i = 0; i < pathwayID.length; i++) {
+        pwLink = pwLink += '<a href="/view/PathwayMap/?annotation=PATRIC&genome_id=' + genomeID[i] + '&pathway_id=' + pathwayID[i] + '&feature_id=' + featureID[i] + '" target="_blank">KEGG:' + pathwayID[i] + '</a>&nbsp;' + pathwayName[i] + '<br>';
       }
 
       var htr = domConstruct.create('tr', {}, tbody);

--- a/public/js/p3/widget/FeatureOverview.js
+++ b/public/js/p3/widget/FeatureOverview.js
@@ -328,16 +328,27 @@ define([
       var tbody = tbodyQuery[0];
 
       var pwLink;
-      var ecLink;
       if (data) {
-        ecLink = data.map(function (row) {
-          return '<a href="http://enzyme.expasy.org/EC/' + row.ec_number + '" target=_blank>' + row.ec_number + '</a>&nbsp;' + row.ec_description;
-        }).join('<br>');
-
         pwLink = data.map(function (row) {
           return '<a href="/view/PathwayMap/?annotation=PATRIC&genome_id=' + row.genome_id + '&pathway_id=' + row.pathway_id + '&feature_id=' + row.feature_id + '" target="_blank">KEGG:' + row.pathway_id + '</a>&nbsp;' + row.pathway_name;
         }).join('<br>');
       }
+
+      var ecNum = data.map(function(el) {
+        return el.ec_number;
+      });
+      var ecNumber = Array.from(new Set(ecNum));
+
+      var ecDesc = data.map(function(el) {
+        return el.ec_description;
+      });
+      var ecDescription = Array.from(new Set(ecDesc));
+
+      var ecLink = "";
+      for (var i = 0; i < ecNumber.length; i++) {
+        ecLink = ecLink += '<a href="http://enzyme.expasy.org/EC/' + ecNumber[i] + '" target=_blank>' + ecNumber[i] + '</a>&nbsp;' + ecDescription[i] + '<br>';
+      }
+
       var htr = domConstruct.create('tr', {}, tbody);
       domConstruct.create('th', { innerHTML: 'EC Numbers', scope: 'row' }, htr);
       domConstruct.create('td', { innerHTML: ecLink || '-' }, htr);


### PR DESCRIPTION
Some  data objects on feature overview pages were displaying duplicate EC Numbers and Pathways. This parses and checks the data object for duplicates and displays only the unique information, links, text, etc.

**Before:**

![Screenshot_2020-01-13 fig 300267 13 peg 1 Feature Overview](https://user-images.githubusercontent.com/22353987/72306551-2206d700-363d-11ea-9e66-189e2c7681df.png)

**After:**

![Screenshot_2020-01-13 fig 300267 13 peg 1 Feature Overview(1)](https://user-images.githubusercontent.com/22353987/72306567-31862000-363d-11ea-98a2-7a27f02ef53f.png)
