### PR TITLE
Supporting gzip for genome distance in the interface.

### DIFF
--- a/public/js/p3/widget/app/GenomeDistance.js
+++ b/public/js/p3/widget/app/GenomeDistance.js
@@ -132,7 +132,7 @@ define([
         }
         document.getElementsByClassName('searchBy')[0].innerHTML = path;
         WorkspaceManager.getObject(path, true).then(lang.hitch(this, function (file) {
-          var isZip = (file.name.endsWith('.gz') || file.name.endsWith('.zip'));
+          var isZip = (file.name.endsWith('.bzip') || file.name.endsWith('.bz2') || file.name.endsWith('.zip'));
           if (file.link_reference && file.size > 0 && this.fasta.type.indexOf(file.type) >= 0 && !isZip) {
             var q = {
               method: 'Minhash.compute_genome_distance_for_fasta',
@@ -140,9 +140,9 @@ define([
             };
             def.resolve(q);
           } else {
-            var message = 'File is not loaded completely.';
+            var message = 'File was not loaded.';
             if (isZip) {
-              message = 'Currently compressed files not supported';
+              message = 'The compression format is not supported.  Use gzip.';
             }
             Topic.publish('GenomeDistance_UI', 'showErrorMessage', message);
             def.reject();

--- a/public/js/p3/widget/app/templates/GenomeDistance.html
+++ b/public/js/p3/widget/app/templates/GenomeDistance.html
@@ -84,7 +84,7 @@
                         <label class="paramlabel">Distance: </label><br/>
                         <div data-dojo-type="dijit/form/Select"
                              data-dojo-attach-point="distance"
-                             value="0.05" style="width:60px">
+                             value="1" style="width:60px">
                             <option value="0.01">0.01</option>
                             <option value="0.05">0.05</option>
                             <option value="0.1">0.1</option>


### PR DESCRIPTION
Changed the default distance to 1 since this may be more helpful for less technical users.
Changed the interface to support gzip compressed files.  This change is in conjunction with p3_minhash changes.