### PR TITLE
Video buttons & links: annotation, assembly, and family sorter

### DIFF
--- a/public/js/p3/resources/p3.css
+++ b/public/js/p3/resources/p3.css
@@ -389,6 +389,10 @@ table tr.even td {
     color: #e75200;
 }
 
+.videoButton > a:hover {
+    text-decoration: none;
+}
+
 .fileUploadButton {
     position: relative;
     overflow: hidden;

--- a/public/js/p3/widget/app/Annotation.js
+++ b/public/js/p3/widget/app/Annotation.js
@@ -17,6 +17,7 @@ define([
     applicationDescription: 'The Genome Annotation Service uses the RAST tool kit (RASTtk) to provide annotation of genomic features.',
     applicationHelp: 'user_guides/services/genome_annotation_service.html',
     tutorialLink: 'tutorial/genome_annotation/annotation.html',
+    videoLink: 'videos/genome_annotation_service.html',
     pageTitle: 'Genome Annotation Service',
     required: true,
     genera_four: ['Acholeplasma', 'Entomoplasma', 'Hepatoplasma', 'Hodgkinia', 'Mesoplasma', 'Mycoplasma', 'Spiroplasma', 'Ureaplasma'],

--- a/public/js/p3/widget/app/AppBase.js
+++ b/public/js/p3/widget/app/AppBase.js
@@ -115,18 +115,6 @@ define([
           });
         }
       });
-
-      var videos = query('.videoButton');
-      var videoLink = PathJoin(this.docsServiceURL, (this.videoLink || 'videos/'));
-      videos.forEach(function (item) {
-        if (domClass.contains(item, 'videoInfo')) {
-          on(item, 'click', function () {
-            // console.log(tutorialLink)
-            window.open(videoLink, 'Video Tutorials');
-          });
-        }
-      });
-
     },
 
     onOutputPathChange: function (val) {

--- a/public/js/p3/widget/app/AppBase.js
+++ b/public/js/p3/widget/app/AppBase.js
@@ -116,6 +116,17 @@ define([
         }
       });
 
+      var videos = query('.videoButton');
+      var videoLink = PathJoin(this.docsServiceURL, (this.videoLink || 'videos/'));
+      videos.forEach(function(item) {
+        if (domClass.contains(item, 'videoInfo')) {
+          on(item, 'click', function () {
+            // console.log(tutorialLink)
+            window.open(videoLink, 'Video Tutorials');
+          });
+        }
+      });
+
     },
 
     onOutputPathChange: function (val) {

--- a/public/js/p3/widget/app/AppBase.js
+++ b/public/js/p3/widget/app/AppBase.js
@@ -118,7 +118,7 @@ define([
 
       var videos = query('.videoButton');
       var videoLink = PathJoin(this.docsServiceURL, (this.videoLink || 'videos/'));
-      videos.forEach(function(item) {
+      videos.forEach(function (item) {
         if (domClass.contains(item, 'videoInfo')) {
           on(item, 'click', function () {
             // console.log(tutorialLink)

--- a/public/js/p3/widget/app/Assembly2.js
+++ b/public/js/p3/widget/app/Assembly2.js
@@ -24,6 +24,7 @@ define([
     applicationDescription: 'The Genome Assembly Service allows single or multiple assemblers to be invoked to compare results. The service attempts to select the best assembly.',
     applicationHelp: 'user_guides/services/genome_assembly_service2.html',
     tutorialLink: 'tutorial/genome_assembly/assembly2.html',
+    videoLink: 'videos/genome_assembly_service.html',
     libraryData: null,
     defaultPath: '',
     startingRows: 13,

--- a/public/js/p3/widget/app/ProteinFamily.js
+++ b/public/js/p3/widget/app/ProteinFamily.js
@@ -19,6 +19,7 @@ define([
     applicationName: 'ProteinFamily',
     applicationHelp: 'user_guides/services/protein_family_service.html',
     tutorialLink: 'tutorial/protein_family_sorter/protein_family_sorter.html',
+    videoLink: 'videos/protein_family_sorter.html',
     pageTitle: 'Protein Family Sorter',
     libraryData: null,
     defaultPath: '',

--- a/public/js/p3/widget/app/templates/Annotation.html
+++ b/public/js/p3/widget/app/templates/Annotation.html
@@ -10,7 +10,7 @@
           <i class="fa icon-books fa-1x" title="click to open tutorial"></i>
         </div>
         <div class="infobox iconbox videoButton videoInfo">
-          <i class="fa icon-play-circle fa-1x" title="click to open the video tutorial"></i>
+          <a href="${docsServiceURL}${videoLink}" target="_blank" ><i class="fa icon-play-circle fa-1x" title="click to open the video tutorial"></i></a>
         </div>
       </h3>
       <p>${applicationDescription} For further explanation, please see <a href="${docsServiceURL}${applicationHelp}" target="_blank">${applicationLabel} Service User Guide</a>, <a href="${docsServiceURL}${tutorialLink}" target="_blank">Tutorial</a>, and <a href="${docsServiceURL}${videoLink}" target="_blank" >Instructional Video</a>.</p>

--- a/public/js/p3/widget/app/templates/Annotation.html
+++ b/public/js/p3/widget/app/templates/Annotation.html
@@ -9,10 +9,11 @@
         <div class="infobox iconbox tutorialButton tutorialInfo">
           <i class="fa icon-books fa-1x" title="click to open tutorial"></i>
         </div>
+        <div class="infobox iconbox videoButton videoInfo">
+          <i class="fa icon-play-circle fa-1x" title="click to open the video tutorial"></i>
+        </div>
       </h3>
-      <p>${applicationDescription} For further explanation, please see <a href="${docsServiceURL}${applicationHelp}" target="_blank">${applicationLabel} Service User Guide</a> and
-        <a href="${docsServiceURL}${tutorialLink}" target="_blank">Tutorial</a>.
-      </p>
+      <p>${applicationDescription} For further explanation, please see <a href="${docsServiceURL}${applicationHelp}" target="_blank">${applicationLabel} Service User Guide</a>, <a href="${docsServiceURL}${tutorialLink}" target="_blank">Tutorial</a>, and <a href="${docsServiceURL}${videoLink}" target="_blank" >Instructional Video</a>.</p>
     </div>
     <div style="width:450px; margin:auto" class="formFieldsContainer">
       <div id="annotationBox" style="width:400px;" class="appBox appShadow">

--- a/public/js/p3/widget/app/templates/Assembly2.html
+++ b/public/js/p3/widget/app/templates/Assembly2.html
@@ -9,10 +9,11 @@
         <div class="infobox iconbox tutorialButton tutorialInfo">
           <i class="fa icon-books fa-1x" title="click to open tutorial"></i>
         </div>
+        <div class="infobox iconbox videoButton videoInfo">
+          <i class="fa icon-play-circle fa-1x" title="click to open the video tutorial"></i>
+        </div>
       </h3>
-      <p>${applicationDescription} For further explanation, please see <a href="${docsServiceURL}${applicationHelp}" target="_blank">${applicationLabel} Service User Guide</a>        and
-        <a href="${docsServiceURL}${tutorialLink}" target="_blank">Tutorial</a>.
-      </p>
+      <p>${applicationDescription} For further explanation, please see <a href="${docsServiceURL}${applicationHelp}" target="_blank">${applicationLabel} Service User Guide</a>, <a href="${docsServiceURL}${tutorialLink}" target="_blank">Tutorial</a>, and <a href="${docsServiceURL}${videoLink}" target="_blank" >Instructional Video</a>.</p>
     </div>
     <div class="formFieldsContainer">
       <div style="display: none;">

--- a/public/js/p3/widget/app/templates/Assembly2.html
+++ b/public/js/p3/widget/app/templates/Assembly2.html
@@ -10,7 +10,7 @@
           <i class="fa icon-books fa-1x" title="click to open tutorial"></i>
         </div>
         <div class="infobox iconbox videoButton videoInfo">
-          <i class="fa icon-play-circle fa-1x" title="click to open the video tutorial"></i>
+          <a href="${docsServiceURL}${videoLink}" target="_blank" ><i class="fa icon-play-circle fa-1x" title="click to open the video tutorial"></i></a>
         </div>
       </h3>
       <p>${applicationDescription} For further explanation, please see <a href="${docsServiceURL}${applicationHelp}" target="_blank">${applicationLabel} Service User Guide</a>, <a href="${docsServiceURL}${tutorialLink}" target="_blank">Tutorial</a>, and <a href="${docsServiceURL}${videoLink}" target="_blank" >Instructional Video</a>.</p>

--- a/public/js/p3/widget/app/templates/ProteinFamily.html
+++ b/public/js/p3/widget/app/templates/ProteinFamily.html
@@ -11,7 +11,7 @@
                 <i class="fa icon-books fa-1x" title="click to open tutorial"></i>
               </div>
               <div class="infobox iconbox videoButton videoInfo">
-                <i class="fa icon-play-circle fa-1x" title="click to open the video tutorial"></i>
+                <a href="${docsServiceURL}${videoLink}" target="_blank" ><i class="fa icon-play-circle fa-1x" title="click to open the video tutorial"></i></a>
               </div>
             </h3>
             <p>${applicationDescription} For further explanation, please see <a href="${docsServiceURL}${applicationHelp}" target="_blank">${applicationLabel} Service User Guide</a>, <a href="${docsServiceURL}${tutorialLink}" target="_blank">Tutorial</a>, and <a href="${docsServiceURL}${videoLink}" target="_blank" >Instructional Video</a>.</p>

--- a/public/js/p3/widget/app/templates/ProteinFamily.html
+++ b/public/js/p3/widget/app/templates/ProteinFamily.html
@@ -10,11 +10,11 @@
               <div class="infobox iconbox tutorialButton tutorialInfo">
                 <i class="fa icon-books fa-1x" title="click to open tutorial"></i>
               </div>
+              <div class="infobox iconbox videoButton videoInfo">
+                <i class="fa icon-play-circle fa-1x" title="click to open the video tutorial"></i>
+              </div>
             </h3>
-            <p>The Protein Family Sorter tool enables researchers to examine the distribution of specific protein families across different genomes.
-                For further explanation, please see <a href="${docsServiceURL}${applicationHelp}" target="_blank">Protein Family Sorter User Guide</a> and
-                <a href="${docsServiceURL}${tutorialLink}" target="_blank">Tutorial</a>.
-            </p>
+            <p>${applicationDescription} For further explanation, please see <a href="${docsServiceURL}${applicationHelp}" target="_blank">${applicationLabel} Service User Guide</a>, <a href="${docsServiceURL}${tutorialLink}" target="_blank">Tutorial</a>, and <a href="${docsServiceURL}${videoLink}" target="_blank" >Instructional Video</a>.</p>
         </div>
         <div class="formFieldsContainer">
             <div style="display: none;">


### PR DESCRIPTION
Added video buttons and links to their respective video tutorial on annotation, assembly, and family sorter service pages.

https://github.com/PATRIC3/patric3_website/issues/2360

<img width="749" alt="Screen Shot 2020-06-01 at 3 35 33 PM" src="https://user-images.githubusercontent.com/22353987/83452010-8a542a80-a41d-11ea-8433-237d7f25f7e7.png">