### PR TITLE
Features/sars cov 2

### DIFF
--- a/public/js/p3/widget/app/templates/ComprehensiveSARS2Analysis.html
+++ b/public/js/p3/widget/app/templates/ComprehensiveSARS2Analysis.html
@@ -12,7 +12,7 @@
         </div>
         -->
       </h3>
-      <p>${applicationDescription} For further explanation, please see the ${applicationLabel} Service  <a href="${docsServiceURL}${applicationHelp}"
+      <p>${applicationDescription} For further explanation, please see the ${applicationLabel} Service  <a href="https://test.bv-brc.org/docs/user-guides/sars-cov-2"
           target="_blank">User Guide</a> and
         <a href="${docsServiceURL}${tutorialLink}" target="_blank">Tutorial</a>.
       </p>


### PR DESCRIPTION
This hard codes a new URL for the user guide related to the SARS-CoV-2 service.

Until we get a dedicated documentation site up for BV-BRC the doc files can live within BV-BRC itself and will retain the current header, footer, etc without directing the user to PATRIC's documentation. 