### PR TITLE
add spaces to comma-separated link lists in meta tables

### DIFF
--- a/public/js/p3/widget/DataItemFormatter.js
+++ b/public/js/p3/widget/DataItemFormatter.js
@@ -27,7 +27,9 @@ define([
 
   function evaluateLink(link, value, item) {
     return (link && value !== '-' && value !== '0') ? (
-      (typeof (link) == 'function') ? link.apply(this, [item]) : '<a href="' + link + value + '" target="_blank">' + value + '</a>'
+      (typeof (link) == 'function') ?
+        link.apply(this, [item]) :
+        '<a href="' + link + value + '" target="_blank">' + String(value).split(',').join(', ') + '</a>'
     ) : value;
   }
 

--- a/public/js/p3/widget/app/AppBase.js
+++ b/public/js/p3/widget/app/AppBase.js
@@ -290,6 +290,13 @@ define([
           charError.innerHTML = '&nbsp;';
         }
       }
+    },
+
+    onAddSRR: function () {
+      var accession = this.srr_accession.get('value');
+      var lrec = { _type: 'srr_accession', title: accession };
+      this.ingestAttachPoints(['srr_accession'], lrec);
+      this.addLibraryRow(lrec, {}, 'srrdata');
     }
   });
 });

--- a/public/js/p3/widget/app/Assembly2.js
+++ b/public/js/p3/widget/app/Assembly2.js
@@ -338,7 +338,7 @@ define([
         this.addLibraryRow(lrec, infoLabels, 'singledata');
       }
     },
-
+    /*
     onAddSRR: function () {
       var accession = this.srr_accession.get('value');
       if ( !accession.match(/^[a-z0-9]+$/i)) {
@@ -369,7 +369,9 @@ define([
             }
           }));
       }
+
     },
+    */
 
     destroyLibRow: function (query_id, id_type) {
       var query_obj = {};

--- a/public/js/p3/widget/app/ComprehensiveGenomeAnalysis.js
+++ b/public/js/p3/widget/app/ComprehensiveGenomeAnalysis.js
@@ -293,6 +293,7 @@ define([
       }
     },
 
+    /*
     onAddSRR: function () {
       var accession = this.srr_accession.get('value');
       if ( !accession.match(/^[a-z0-9]+$/i)) {
@@ -324,6 +325,7 @@ define([
           }));
       }
     },
+    */
 
     destroyLibRow: function (query_id, id_type) {
       var query_obj = {};

--- a/public/js/p3/widget/app/FastqUtil.js
+++ b/public/js/p3/widget/app/FastqUtil.js
@@ -120,7 +120,6 @@ define([
       this._started = true;
     },
 
-
     onAddSRR: function () {
       console.log('Create New Row', domConstruct);
       var toIngest = this.srrToAttachPt;
@@ -194,6 +193,7 @@ define([
           }
         }));
     },
+
     addLibraryInfo: function (lrec, infoLabels, tr) {
       var advInfo = [];
       // fill out the html of the info mouse over

--- a/public/js/p3/widget/app/FunctionalClassification.js
+++ b/public/js/p3/widget/app/FunctionalClassification.js
@@ -270,6 +270,7 @@ define([
       }
     },
 
+    /*
     onAddSRR: function () {
       var accession = this.srr_accession.get('value');
 
@@ -297,6 +298,7 @@ define([
           }
         }));
     },
+    */
 
     destroyLibRow: function (query_id, id_type) {
       var query_obj = {};

--- a/public/js/p3/widget/app/MetagenomicReadMapping.js
+++ b/public/js/p3/widget/app/MetagenomicReadMapping.js
@@ -271,6 +271,7 @@ define([
       }
     },
 
+    /*
     onAddSRR: function () {
       var accession = this.srr_accession.get('value');
 
@@ -298,6 +299,7 @@ define([
           }
         }));
     },
+    */
 
     destroyLibRow: function (query_id, id_type) {
       var query_obj = {};

--- a/public/js/p3/widget/app/TaxonomicClassification.js
+++ b/public/js/p3/widget/app/TaxonomicClassification.js
@@ -281,6 +281,7 @@ define([
       }
     },
 
+    /*
     onAddSRR: function () {
       var accession = this.srr_accession.get('value');
 
@@ -308,6 +309,7 @@ define([
           }
         }));
     },
+    */
 
     destroyLibRow: function (query_id, id_type) {
       var query_obj = {};

--- a/public/js/p3/widget/app/templates/FastqUtil.html
+++ b/public/js/p3/widget/app/templates/FastqUtil.html
@@ -111,13 +111,13 @@
             <div class="appBox appShadow">
               <div class="headerrow">
                 <div style="width:85%;display:inline-block;">
-                  <label class="appBoxLabel">SRA run accession</label>
+                  <label class="appBoxLabel">SRA run accession <small>(Temporarily Disabled)</small></label>
                 </div>
                 <div style="width:10%;display:inline-block;"><i data-dojo-attach-event="click:onAddSRR" class="fa icon-arrow-circle-o-right fa-lg"></i></div>
               </div>
               <div class="appRow">
                 <label class="paramlabel">SRR Accession</label><br>
-                <div data-dojo-type="dijit/form/ValidationTextBox" data-dojo-attach-event="onChange:updateSRR" data-dojo-attach-point="srr_accession" style="width: 300px" required="false" data-dojo-props="intermediateChanges:true, missingMessage:'You must provide an accession', trim:true, placeHolder:'SRR'"></div>
+                <div data-dojo-type="dijit/form/ValidationTextBox" data-dojo-attach-event="onChange:updateSRR" data-dojo-attach-point="srr_accession" style="width: 300px" required="false" data-dojo-props="disabled:true,intermediateChanges:true, missingMessage:'You must provide an accession', trim:true, placeHolder:'SRR'"></div>
               </div>
             </div>
           </td>

--- a/public/js/p3/widget/app/templates/Rnaseq.html
+++ b/public/js/p3/widget/app/templates/Rnaseq.html
@@ -141,13 +141,13 @@
             <div class="appBox appShadow">
               <div class="headerrow">
                 <div style="width:85%;display:inline-block;">
-                  <label class="appBoxLabel">SRA run accession</label>
+                  <label class="appBoxLabel">SRA run accession <small>(Temporarily Disabled)</small></label>
                 </div>
                 <div style="width:10%;display:inline-block;"><i data-dojo-attach-event="click:onAddSRR" class="fa icon-arrow-circle-o-right fa-lg"></i></div>
               </div>
               <div class="appRow">
                 <label class="paramlabel">SRR Accession</label><br>
-                <div data-dojo-type="dijit/form/ValidationTextBox" data-dojo-attach-event="onChange:updateSRR" data-dojo-attach-point="srr_accession" style="width: 300px" required="false" data-dojo-props="intermediateChanges:true, missingMessage:'You must provide an accession', trim:true, placeHolder:'SRR'"></div>
+                <div data-dojo-type="dijit/form/ValidationTextBox" data-dojo-attach-event="onChange:updateSRR" data-dojo-attach-point="srr_accession" style="width: 300px" required="false" data-dojo-props="disabled: true,intermediateChanges:true, missingMessage:'You must provide an accession', trim:true, placeHolder:'SRR'"></div>
               </div>
               <div class="appRow">
                 <label class="paramlabel">Condition</label><br>


### PR DESCRIPTION
Some genomes have a lot of gbk accessions, refseq accessions, publications, etc.  I turned off `word-wrap: break-word;` because that was confusing, but then this happens:

![image](https://user-images.githubusercontent.com/1194246/90275322-b5002d80-de27-11ea-99ee-c39d3b2b2c4b.png)


So this makes things tidy:

![image](https://user-images.githubusercontent.com/1194246/90275592-293ad100-de28-11ea-84ea-774ff1f950d1.png)

