### PR TITLE
Bug fix for handling trees

### DIFF
--- a/public/js/p3/widget/viewer/PhylogeneticTree.js
+++ b/public/js/p3/widget/viewer/PhylogeneticTree.js
@@ -227,6 +227,7 @@ define([
         return true;
       }, function (err) {
         console.error('Error Retreiving Genomes: ', err);
+        _self.viewer.processTreeData(treeDat, idType);
         return false;
       });
       return true;


### PR DESCRIPTION
Tree's with non-queryable ID's should still display.
Should be deployed on BVBRC as well.